### PR TITLE
[Feature] 공통 컴포넌트인 단잠 스위치를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -30,11 +30,11 @@ import com.saeongjima.designsystem.theme.Error
 import com.saeongjima.designsystem.theme.MainColor
 import com.saeongjima.designsystem.theme.Pink40
 
-const val switchWidth = 52
-const val switchHeight = 32
-const val thumbSize = 24
-const val thumbPadding = 2
-const val thumbOffset = 10
+private const val switchWidth = 52
+private const val switchHeight = 32
+private const val thumbSize = 24
+private const val thumbPadding = 2
+private const val thumbOffset = 10
 
 @Composable
 fun DanjamSwitch(

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -86,35 +86,38 @@ fun DanjamSwitch(
 
 @Preview
 @Composable
-private fun DanjamSwitchPreviewChecked() {
+fun DanjamSwitchPreviewChecked() {
     DanjamTheme {
+        var switchState by remember { mutableStateOf(true) }
         DanjamSwitch(
-            checked = true,
-            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
+            checked = switchState,
+            onCheckedChange = { switchState = it }
         )
     }
 }
 
 @Preview
 @Composable
-private fun DanjamSwitchPreviewNotChecked() {
+fun DanjamSwitchPreviewNotChecked() {
     DanjamTheme {
+        var switchState by remember { mutableStateOf(false) }
         DanjamSwitch(
-            checked = false,
-            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
+            checked = switchState,
+            onCheckedChange = { switchState = it }
         )
     }
 }
 
 @Preview
 @Composable
-private fun DanjamSwitchDifferentColorPreviewChecked() {
+fun DanjamSwitchPreviewDifferentColor() {
     DanjamTheme {
+        var switchState by remember { mutableStateOf(true) }
         DanjamSwitch(
-            checked = true,
+            checked = switchState,
             checkedTrackColor = Error,
             thumbColor = Pink40,
-            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
+            onCheckedChange = { switchState = it }
         )
     }
 }

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -26,11 +26,11 @@ import com.saeongjima.designsystem.theme.Error
 import com.saeongjima.designsystem.theme.MainColor
 import com.saeongjima.designsystem.theme.Pink40
 
-private val SWITCH_WIDTH = 52.dp
-private val SWITCH_HEIGHT = 32.dp
-private val THUMB_SIZE = 24.dp
-private val THUMB_PADDING = 2.dp
-private val THUMB_OFFSET = 10.dp
+const val switchWidth = 52
+const val switchHeight = 32
+const val thumbSize = 24
+const val thumbPadding = 2
+const val thumbOffset = 10
 
 @Composable
 fun DanjamSwitch(
@@ -44,7 +44,7 @@ fun DanjamSwitch(
 
     Box(
         modifier = Modifier
-            .size(SWITCH_WIDTH, SWITCH_HEIGHT)
+            .size(switchWidth.dp, switchHeight.dp)
             .clickable {
                 isChecked = !isChecked
                 onCheckedChange(isChecked)
@@ -57,19 +57,19 @@ fun DanjamSwitch(
                 .fillMaxSize()
                 .background(
                     color = if (isChecked) checkedTrackColor else uncheckedTrackColor,
-                    shape = RoundedCornerShape(SWITCH_HEIGHT / 2)
+                    shape = RoundedCornerShape(switchHeight.dp / 2)
                 )
         )
         // Thumb
         Box(
             modifier = Modifier
-                .size(THUMB_SIZE)
-                .offset(x = if (isChecked) THUMB_OFFSET else -THUMB_OFFSET)
+                .size(thumbSize.dp)
+                .offset(x = if (isChecked) thumbOffset.dp else -thumbOffset.dp)
                 .background(
                     color = thumbColor,
                     shape = CircleShape
                 )
-                .padding(THUMB_PADDING)
+                .padding(thumbPadding.dp)
         )
     }
 }

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.unit.dp
 import com.saeongjima.designsystem.theme.Black200
 import com.saeongjima.designsystem.theme.Black900
 import com.saeongjima.designsystem.theme.DanjamTheme
+import com.saeongjima.designsystem.theme.Error
 import com.saeongjima.designsystem.theme.MainColor
+import com.saeongjima.designsystem.theme.Pink40
 
 private val SWITCH_WIDTH = 52.dp
 private val SWITCH_HEIGHT = 32.dp
@@ -89,6 +91,19 @@ private fun DanjamSwitchPreviewNotChecked() {
     DanjamTheme {
         DanjamSwitch(
             checked = false,
+            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DanjamSwitchDifferentColorPreviewChecked() {
+    DanjamTheme {
+        DanjamSwitch(
+            checked = true,
+            checkedTrackColor = Error,
+            thumbColor = Pink40,
             onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
         )
     }

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -1,0 +1,63 @@
+package com.saeongjima.designsystem.component.switch
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.saeongjima.designsystem.theme.Black200
+import com.saeongjima.designsystem.theme.Black900
+import com.saeongjima.designsystem.theme.DanjamTheme
+
+@Composable
+fun DanjamSwitch(
+    checked: Boolean,
+    checkedTrackColor: Color = MaterialTheme.colorScheme.primary,
+    uncheckedTrackColor: Color = Black200,
+    thumbColor: Color = Black900,
+    onCheckedChange: ((Boolean) -> Unit)? = null
+) {
+    var isChecked by remember { mutableStateOf(checked) }
+
+    Switch(
+        checked = isChecked,
+        onCheckedChange = {
+            isChecked = it
+            onCheckedChange?.invoke(it)
+        },
+        colors = SwitchDefaults.colors(
+            checkedThumbColor = thumbColor,
+            uncheckedThumbColor = thumbColor,
+            checkedTrackColor = checkedTrackColor,
+            uncheckedTrackColor = uncheckedTrackColor,
+            uncheckedBorderColor = uncheckedTrackColor,
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun DanjamSwitchPreviewChecked() {
+    DanjamTheme {
+        DanjamSwitch(
+            checked = true,
+            onCheckedChange = { /* 스위치 전환시 이벤트를 구현 합니다. */ }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DanjamSwitchPreviewNotChecked() {
+    DanjamTheme {
+        DanjamSwitch(
+            checked = false,
+            onCheckedChange = { /* 스위치 전환시 이벤트를 구현 합니다. */ }
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -1,43 +1,75 @@
 package com.saeongjima.designsystem.component.switch
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.saeongjima.designsystem.theme.Black200
 import com.saeongjima.designsystem.theme.Black900
 import com.saeongjima.designsystem.theme.DanjamTheme
+import com.saeongjima.designsystem.theme.MainColor
+
+private val SWITCH_WIDTH = 52.dp
+private val SWITCH_HEIGHT = 32.dp
+private val THUMB_SIZE = 24.dp
+private val THUMB_PADDING = 2.dp
+private val THUMB_OFFSET = 10.dp
 
 @Composable
 fun DanjamSwitch(
     checked: Boolean,
-    checkedTrackColor: Color = MaterialTheme.colorScheme.primary,
+    onCheckedChange: (Boolean) -> Unit,
+    checkedTrackColor: Color = MainColor,
     uncheckedTrackColor: Color = Black200,
     thumbColor: Color = Black900,
-    onCheckedChange: ((Boolean) -> Unit)? = null
 ) {
     var isChecked by remember { mutableStateOf(checked) }
 
-    Switch(
-        checked = isChecked,
-        onCheckedChange = {
-            isChecked = it
-            onCheckedChange?.invoke(it)
-        },
-        colors = SwitchDefaults.colors(
-            checkedThumbColor = thumbColor,
-            uncheckedThumbColor = thumbColor,
-            checkedTrackColor = checkedTrackColor,
-            uncheckedTrackColor = uncheckedTrackColor,
-            uncheckedBorderColor = uncheckedTrackColor,
+    Box(
+        modifier = Modifier
+            .size(SWITCH_WIDTH, SWITCH_HEIGHT)
+            .clickable {
+                isChecked = !isChecked
+                onCheckedChange(isChecked)
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        // Track
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = if (isChecked) checkedTrackColor else uncheckedTrackColor,
+                    shape = RoundedCornerShape(SWITCH_HEIGHT / 2)
+                )
         )
-    )
+        // Thumb
+        Box(
+            modifier = Modifier
+                .size(THUMB_SIZE)
+                .offset(x = if (isChecked) THUMB_OFFSET else -THUMB_OFFSET)
+                .background(
+                    color = thumbColor,
+                    shape = CircleShape
+                )
+                .padding(THUMB_PADDING)
+        )
+    }
 }
 
 @Preview
@@ -46,7 +78,7 @@ private fun DanjamSwitchPreviewChecked() {
     DanjamTheme {
         DanjamSwitch(
             checked = true,
-            onCheckedChange = { /* 스위치 전환시 이벤트를 구현 합니다. */ }
+            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
         )
     }
 }
@@ -57,7 +89,7 @@ private fun DanjamSwitchPreviewNotChecked() {
     DanjamTheme {
         DanjamSwitch(
             checked = false,
-            onCheckedChange = { /* 스위치 전환시 이벤트를 구현 합니다. */ }
+            onCheckedChange = { /* 스위치 전환시 상태 변환 처리 및 추가 작업을 수행합니다. */ }
         )
     }
 }

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,6 +56,7 @@ fun DanjamSwitch(
     Box(
         modifier = Modifier
             .size(switchWidth.dp, switchHeight.dp)
+            .clip(RoundedCornerShape(switchHeight.dp / 2))
             .clickable {
                 isChecked = !isChecked
                 onCheckedChange(isChecked)

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -1,5 +1,8 @@
 package com.saeongjima.designsystem.component.switch
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -41,6 +44,13 @@ fun DanjamSwitch(
     thumbColor: Color = Black900,
 ) {
     var isChecked by remember { mutableStateOf(checked) }
+    val animateThumbOffset by animateDpAsState(
+        targetValue = if (isChecked) thumbOffset.dp else -thumbOffset.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMedium
+        )
+    )
 
     Box(
         modifier = Modifier
@@ -64,7 +74,7 @@ fun DanjamSwitch(
         Box(
             modifier = Modifier
                 .size(thumbSize.dp)
-                .offset(x = if (isChecked) thumbOffset.dp else -thumbOffset.dp)
+                .offset(x = animateThumbOffset)
                 .background(
                     color = thumbColor,
                     shape = CircleShape

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/switch/DanjamSwtich.kt
@@ -44,9 +44,8 @@ fun DanjamSwitch(
     uncheckedTrackColor: Color = Black200,
     thumbColor: Color = Black900,
 ) {
-    var isChecked by remember { mutableStateOf(checked) }
     val animateThumbOffset by animateDpAsState(
-        targetValue = if (isChecked) thumbOffset.dp else -thumbOffset.dp,
+        targetValue = if (checked) thumbOffset.dp else -thumbOffset.dp,
         animationSpec = spring(
             dampingRatio = Spring.DampingRatioNoBouncy,
             stiffness = Spring.StiffnessMedium
@@ -58,8 +57,7 @@ fun DanjamSwitch(
             .size(switchWidth.dp, switchHeight.dp)
             .clip(RoundedCornerShape(switchHeight.dp / 2))
             .clickable {
-                isChecked = !isChecked
-                onCheckedChange(isChecked)
+                onCheckedChange(!checked)
             },
         contentAlignment = Alignment.Center
     ) {
@@ -68,7 +66,7 @@ fun DanjamSwitch(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
-                    color = if (isChecked) checkedTrackColor else uncheckedTrackColor,
+                    color = if (checked) checkedTrackColor else uncheckedTrackColor,
                     shape = RoundedCornerShape(switchHeight.dp / 2)
                 )
         )


### PR DESCRIPTION
## AS-IS
재사용 가능성이 높아보이는 스위치를 프로젝트에 사용할 수 있도록 

## TO-BE
공통 단잠 스위치 컴포넌트로 구현하였습니다.

## KEY-POINT
material switch가 내부 원(thumb)의 크기가 조절이 안되는 이유로 직접 구현을 하였습니다.

offset을 이용하여 스위치 전환되는 효과를 구현하였습니다, 색상변경 가능성을 생각하여 디폴트 값으로 지금 쓰이는 값을 넣어두고 색상을 변경할 수 있도록 하였습니다.

상단에 상수화도 시켜두었는데 이런식으로 작성하는 것이 맞는지 호이스팅은 잘 이루어졌는지 확인해주시면 감사 드리겠습니다.

## SCREENSHOT
[Screen_recording_20240621_042150.webm](https://github.com/Saeongjima/Danjam-android-native/assets/52442547/e2e6e40a-6f91-477b-8043-5d84e106bd22)
